### PR TITLE
Add Gemfile for development dependencies, document install process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+group 'development', 'test' do
+  gem 'rake'
+  gem 'hoe'
+  gem 'rake-compiler'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    hoe (3.7.2)
+      rake (>= 0.8, < 11.0)
+    rake (10.1.0)
+    rake-compiler (0.9.2)
+      rake
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hoe
+  rake
+  rake-compiler

--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,21 @@ end
 
 ## INSTALL:
 
-* FIX (sudo gem install, anything else)
+Compile and run the test suite to make sure you have all the necessary
+compile-time dependencies:
+
+```sh
+rake
+```
+
+Install the gem:
+
+```sh
+rake install_gem
+```
+
+You may need to run `sudo rake install_gem` depending on your Ruby
+installation.
 
 ## LICENSE:
 

--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,7 @@ Compile and run the test suite to make sure you have all the necessary
 compile-time dependencies:
 
 ```sh
+bundle
 rake
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -25,4 +25,6 @@ Hoe.spec 'av_capture' do
   end
 end
 
+task :test => [:compile]
+
 # vim: syntax=ruby


### PR DESCRIPTION
This also makes the default Rake task compile before running the test suite.

I know this is a personal project, so no worries if you can't get to this!

I couldn't get `rake clean` to clean up `lib/av_capture.bundle`.
