### PR TITLE
Add minitest to development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ group 'development', 'test' do
   gem 'rake'
   gem 'hoe'
   gem 'rake-compiler'
+  gem 'minitest'
 end


### PR DESCRIPTION
Most folks have minitest installed already but for those that don't this would clear up any possible confusion when trying to run the initial setup that is outlined in the readme. 
